### PR TITLE
Use different metric for dashboard window when specified

### DIFF
--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -197,14 +197,18 @@ void WebApplication::createWindow(QWebNewPageRequest *request)
 
     // child windows can never be headless ones!
     QString windowType = "card";
+    QString windowMetrics = "";
 
     // check if we got supplied with a different window type
     if (windowFeatures.contains("attributes")) {
         QString attributes = windowFeatures["attributes"].toString();
         QJsonDocument document = QJsonDocument::fromJson(attributes.toUtf8());
+
         QString windowTypeAttrib = document.object().value("window").toString();
         if (windowTypeAttrib.length() > 0)
             windowType = windowTypeAttrib;
+
+        windowMetrics = document.object().value("metrics").toString();
     }
 
     if (windowFeatures.contains("height")) {
@@ -213,6 +217,11 @@ void WebApplication::createWindow(QWebNewPageRequest *request)
             height = windowFeatures["height"].toInt();
         else if (type == QVariant::Double)
             height = static_cast<int>(windowFeatures["height"].toDouble());
+
+        if (windowMetrics == "units") {
+            float gridUnit = Settings::LunaSettings()->gridUnit;
+            height = static_cast<int>(qRound(height * gridUnit));
+        }
     }
 
     qDebug() << Q_FUNC_INFO << "Setting parent window id" << mMainWindow->windowId() << "for new window";


### PR DESCRIPTION
As we're acting with multiple devices at different display sizes we need to have a way to
specified the window height independetly. This adds a new window attribute "metrics" which
can be set to "units" and then the window height is calculated in grid units rather than
in pixels.

Signed-off-by: Simon Busch <morphis@gravedo.de>