### PR TITLE
Fix relaunch

### DIFF
--- a/src/extensions/palmsystemextension.cpp
+++ b/src/extensions/palmsystemextension.cpp
@@ -44,6 +44,7 @@ PalmSystemExtension::PalmSystemExtension(WebApplicationWindow *applicationWindow
     mLunaPubHandle(NULL, true)
 {
     applicationWindow->registerUserScript(QString("://extensions/PalmSystem.js"));
+    connect(applicationWindow->application(), SIGNAL(parametersChanged(bool)), this, SIGNAL(launchParamsChanged(bool)));
 
     mLunaPubHandle.attachToLoop(g_main_context_default());
 }

--- a/src/extensions/palmsystemextension.h
+++ b/src/extensions/palmsystemextension.h
@@ -32,7 +32,7 @@ class PalmSystemExtension : public BaseExtension
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString launchParams READ launchParams CONSTANT)
+    Q_PROPERTY(QString launchParams READ launchParams NOTIFY launchParamsChanged)
     Q_PROPERTY(bool hasAlphaHole READ hasAlphaHole WRITE setHasAlphaHole NOTIFY hasAlphaHoleChanged)
     Q_PROPERTY(QString locale READ locale CONSTANT)
     Q_PROPERTY(QString localeRegion READ localeRegion CONSTANT)
@@ -141,6 +141,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void hasAlphaHoleChanged();
     void windowOrientationChanged();
+    void launchParamsChanged(bool needRelaunch);
 
 private:
     WebApplicationWindow *mApplicationWindow;

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -171,13 +171,11 @@ void WebApplication::relaunch(const QString &parameters)
     qDebug() << __PRETTY_FUNCTION__ << "Relaunching application" << mDescription.getId() << "with parameters" << parameters;
 
     mParameters = parameters;
-    emit parametersChanged();
+    emit parametersChanged(true);
 
     if( !mMainWindow ) {
         createMainWindow();
     }
-
-    mMainWindow->executeScript(QString("Mojo.relaunch();"));
 }
 
 void WebApplication::createMainWindow()

--- a/src/webapplication.h
+++ b/src/webapplication.h
@@ -97,7 +97,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void closed();
-    void parametersChanged();
+    void parametersChanged(bool needRelaunch = false);
 
 private:
     void processParameters();


### PR DESCRIPTION
PalmSystem.launchParams is not a constant, so a signal should be emitted.
However, the modification is sent asynchronously to client side, so
the Mojo.relaunch code must be executed only when the launchParams value
is actually modified on client side.

Includes also webOS-api.js: fixes
 * avoid looping on properties of Array with for..in
 * add missing getNextCallId function implementation

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>