### PR TITLE
PalmSystem.getResource: ensure function arguments are not null

### DIFF
--- a/src/extensions/PalmSystem.js
+++ b/src/extensions/PalmSystem.js
@@ -324,7 +324,9 @@ PalmSystem.keyboardHide = function() {
 }
 
 PalmSystem.getResource = function(a, b) {
-    var result = _webOS.execSync("PalmSystem", "getResource", [a, b]);
+    var _a = a || "";
+    var _b = b || "";
+    var result = _webOS.execSync("PalmSystem", "getResource", [_a, _b]);
 
     if (result.length == 0)
       return "";


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>