### PR TITLE
Make sure we don't prepend when starting with file://

### DIFF
--- a/src/extensions/palmsystemextension.cpp
+++ b/src/extensions/palmsystemextension.cpp
@@ -277,8 +277,8 @@ QString PalmSystemExtension::addBannerMessage(const QString &msgTitle, const QSt
         qDebug() << __PRETTY_FUNCTION__ << "iconUrl was empty. New value after setting mApplicationWindow->application()->icon(): " << iconUrl;
     }
 
-    if( (!msgIconUrl.isEmpty()   && !QFileInfo(msgIconUrl).isAbsolute())     ||
-        (!msgSoundFile.isEmpty() && !QFileInfo(msgSoundFile).isAbsolute()) )
+    if( (!msgIconUrl.isEmpty()   && !QFileInfo(msgIconUrl).isAbsolute() && !msgIconUrl.startsWith("file://"))    ||
+        (!msgSoundFile.isEmpty() && !QFileInfo(msgSoundFile).isAbsolute() && !msgSoundFile.startsWith("file://")) )
     {
         QString appBasePath;
 


### PR DESCRIPTION
This lead to incorrect situations:

soundFile is a relative path:  "file:///usr/palm/sounds/alert.wav"
Final soundFile:  "/usr/palm/applications/org.webosports.app.testr/file:///usr/palm/sounds/alert.wav"
