### PR TITLE
BTManager: Call JS propertyChanged successfully

### DIFF
--- a/src/extensions/BluetoothManager.js
+++ b/src/extensions/BluetoothManager.js
@@ -52,9 +52,9 @@ __BluetoothManager.deviceDisappeared= function(address) {
       navigator.BluetoothManager.ondevicedisappeared(address);
 }
 
-__BluetoothManager.propertyChanged = function(key, deviceInfo) {
+__BluetoothManager.propertyChanged = function(keyValueObject) {
     if (typeof navigator.BluetoothManager.onpropertychanged === 'function')
-      navigator.BluetoothManager.onpropertychanged(key, deviceInfo);
+      navigator.BluetoothManager.onpropertychanged(keyValueObject);
 }
 
 __BluetoothManager.requestPinCode= function(deviceInfo) {

--- a/src/extensions/bluetoothmanager.cpp
+++ b/src/extensions/bluetoothmanager.cpp
@@ -317,7 +317,7 @@ void BluetoothManager::propertyChanged(const QString &key, const QVariant &value
 
     document.setObject(btObj);
     QString payload = document.toJson();
-    mAppEnvironment->executeScript(QString("__BluetoothManager.propertyChanged(%1,%2);").arg(key, payload));
+    mAppEnvironment->executeScript(QString("__BluetoothManager.propertyChanged(%1);").arg(payload));
 }
 
 void BluetoothManager::pairingDone()


### PR DESCRIPTION
Not sure this is the right fix.
Would prefer to pass the two arguments out as originally intended
but it does at least work this way.