### PR TITLE
Don't stop unit if luna-next exits on its own.

### DIFF
--- a/files/systemd/LunaWebAppManager.service
+++ b/files/systemd/LunaWebAppManager.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=The Luna Next WebApp manager
 After=luna-next.service
-BindsTo=luna-next.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Fixes issue #1085, where the LunaNext restart is triggered through a Qt.quit in luna-next's cardshell.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>