### PR TITLE
ApplicationContainer: add the loading-bg image in background

### DIFF
--- a/src/qml/ApplicationContainer.qml
+++ b/src/qml/ApplicationContainer.qml
@@ -70,6 +70,11 @@ Flickable {
         webViewLoader.sourceComponent = webViewComponent;
     }
 
+    Image  {
+        anchors.fill: parent
+        source: "images/loading-bg.png";
+    }
+
     Loader {
         id: webViewLoader
         anchors.left: parent.left

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -12,5 +12,6 @@
         <file>qml/images/palm-notification-button-press.png</file>
         <file>qml/images/palm-notification-button.png</file>
         <file>qml/setupViewport.js</file>
+        <file>qml/images/loading-bg.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Add the loading-bg.png image in the background of the LunaWebEngineView,
so that we get a smoother transition between the window being
mapped and the webview being actually painted.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>