### PR TITLE
palmsystemextension.cpp: No longer prepend SoundFile

### DIFF
--- a/src/extensions/palmsystemextension.cpp
+++ b/src/extensions/palmsystemextension.cpp
@@ -295,16 +295,9 @@ QString PalmSystemExtension::addBannerMessage(const QString &msgTitle, const QSt
             iconUrl.prepend("/");
             iconUrl.prepend(appBasePath);
         }
-
-        if (!msgSoundFile.isEmpty() && !QFileInfo(msgSoundFile).isAbsolute()) {
-            qDebug() << __PRETTY_FUNCTION__ << "soundFile is a relative path: " << msgSoundFile;
-            soundFile.prepend("/");
-            soundFile.prepend(appBasePath);
-        }
     }
 
     qDebug() << __PRETTY_FUNCTION__ << "Final iconUrl: " << iconUrl;
-    qDebug() << __PRETTY_FUNCTION__ << "Final soundFile: " << soundFile;
 
     QJsonObject notificationParams;
     notificationParams.insert("title", msgTitle);


### PR DESCRIPTION
We'll deal with this in luna-next-cardshell instead while dealing with various audio file scenarios for banners.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>