### PR TITLE
Qt 5.13: take DPI into account

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include <systemd/sd-daemon.h>
 
 #include <LocalePreferences.h>
+#include <Settings.h>
 
 #include "webappmanager.h"
 #include "systemtime.h"
@@ -82,7 +83,8 @@ int main(int argc, char **argv)
         setenv("QT_QPA_PLATFORM", "wayland", 0);
         setenv("XDG_RUNTIME_DIR", XDG_RUNTIME_DIR_DEFAULT, 0);
         setenv("QT_IM_MODULE", "Maliit", 0);
-        setenv("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1", 1);
+        setenv("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1", 0);
+        setenv("QT_SCALE_FACTOR", QString::number(Settings::LunaSettings()->layoutScale, 'f').toLatin1().constData(), 0);
     }
 
     QString storagePath = "/media/cryptofs/.sysmgr";

--- a/src/qml/ApplicationContainer.qml
+++ b/src/qml/ApplicationContainer.qml
@@ -96,7 +96,7 @@ Flickable {
 
                 var positiveSpace = {
                     width: webViewContainer.width,
-                    height: webViewContainer.height - (Qt.inputMethod ? Qt.inputMethod.keyboardRectangle.height : 0)
+                    height: webViewContainer.height - (Qt.inputMethod ? Qt.inputMethod.keyboardRectangle.height/Screen.pixelDensity : 0)
                 };
 
                 // beware: async call
@@ -105,7 +105,7 @@ Flickable {
                                       "," + positiveSpace.height + ");}");
 
                 if (Qt.inputMethod.visible && webAppWindow.focus)
-                    keyboardContainer.height = Qt.inputMethod.keyboardRectangle.height;
+                    keyboardContainer.height = Qt.inputMethod.keyboardRectangle.height/Screen.pixelDensity;
                 else
                     keyboardContainer.height = 0;
             }
@@ -127,7 +127,6 @@ Flickable {
             backgroundColor: (webAppWindow.windowType === "dashboard" || webAppWindow.windowType === "popupalert") ? "transparent": "white"
 
             userScripts: webAppWindow.userScripts;
-            devicePixelRatio: webAppWindow.devicePixelRatio
 
             onNavigationRequested: {
                 var action = WebEngineView.AcceptRequest;

--- a/src/qml/setupViewport-legacy.js
+++ b/src/qml/setupViewport-legacy.js
@@ -1,0 +1,17 @@
+/*
+ * Some LuneOS apps don't specify any viewport width, which cause the rendering
+ * to be incorrect.
+ * Therefore, force the viewport to contain a "width=device-width" statement.
+ * Also set the user-scalable to 'no' if it's not there specified yet.
+ */
+
+var viewport = document.querySelector("meta[name=viewport]");
+if(viewport) {
+    viewport.setAttribute('content', "width=device-width/__LEGACY_SCALING__, initial-scale=__LEGACY_SCALING__, user-scalable=no");
+}
+else {
+    var metaTag=document.createElement('meta');
+    metaTag.name = "viewport";
+    metaTag.content = "width=device-width/__LEGACY_SCALING__, initial-scale=__LEGACY_SCALING__, user-scalable=no"
+    document.getElementsByTagName('head')[0].appendChild(metaTag);
+}

--- a/src/qml/setupViewport.js
+++ b/src/qml/setupViewport.js
@@ -22,6 +22,6 @@ if(viewport) {
 else {
     var metaTag=document.createElement('meta');
     metaTag.name = "viewport";
-    metaTag.content = "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    metaTag.content = "width=device-width, initial-scale=1.0, user-scalable=no"
     document.getElementsByTagName('head')[0].appendChild(metaTag);
 }

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -11,6 +11,7 @@
         <file>qml/images/palm-notification-button-press.png</file>
         <file>qml/images/palm-notification-button.png</file>
         <file>qml/setupViewport.js</file>
+        <file>qml/setupViewport-legacy.js</file>
         <file>qml/images/loading-bg.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
* use QT_SCALE_FACTOR for all apps
* re-scale legacy apps using the meta viewport tag
* drop the "devicePixelRatio" property usage on WebEngine

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>