### PR TITLE
luna-webappmanager: Add missing ACG files

### DIFF
--- a/files/sysbus/org.webosports.webappmanager.api.json
+++ b/files/sysbus/org.webosports.webappmanager.api.json
@@ -1,0 +1,20 @@
+{
+  "applications.internal": [
+    "com.palm.webappmanager/launchApp",
+    "com.palm.webappmanager/launchUrl",
+    "com.palm.webappmanager/killApp",
+    "com.palm.webappmanager/isAppRunning",
+    "com.palm.webappmanager/listRunningApps",
+    "com.palm.webappmanager/registerForAppEvents",
+    "com.palm.webappmanager/relaunch",
+    "com.palm.webappmanager/clearMemoryCaches",
+    "org.webosports.webappmanager/launchApp",
+    "org.webosports.webappmanager/launchUrl",
+    "org.webosports.webappmanager/killApp",
+    "org.webosports.webappmanager/isAppRunning",
+    "org.webosports.webappmanager/listRunningApps",
+    "org.webosports.webappmanager/registerForAppEvents",
+    "org.webosports.webappmanager/relaunch",
+    "org.webosports.webappmanager/clearMemoryCaches"
+  ]
+}

--- a/files/sysbus/org.webosports.webappmanager.perm.json
+++ b/files/sysbus/org.webosports.webappmanager.perm.json
@@ -1,0 +1,20 @@
+{
+    "com.palm.webappmanager": [
+        "activities",
+        "applications.internal",
+        "networking",
+        "settings.read",
+        "signals.all",
+        "signals.register",
+        "system"
+    ],
+    "org.webosports.webappmanager": [
+        "activities",
+        "applications.internal",
+        "networking",
+        "settings.read",
+        "signals.all",
+        "signals.register",
+        "system"
+    ]
+}

--- a/files/sysbus/org.webosports.webappmanager.role.json
+++ b/files/sysbus/org.webosports.webappmanager.role.json
@@ -1,10 +1,15 @@
 {
     "exeName":"/usr/sbin/LunaWebAppManager",
     "type": "privileged",
-    "allowedNames": ["org.webosports.webappmanager","qtpositioning_LunaWebAppMgr",""],
+    "allowedNames": ["com.palm.webappmanager", "org.webosports.webappmanager","qtpositioning_LunaWebAppMgr",""],
     "permissions": [
         {
             "service":"",
+            "inbound":["*"],
+            "outbound":["*"]
+        },
+        {
+            "service":"com.palm.webappmanager",
             "inbound":["*"],
             "outbound":["*"]
         },


### PR DESCRIPTION
Should solve issues like:

2020-05-17T16:41:52.626365Z [15.340554773] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"launchApp"} Service security groups don't allow method call.
2020-05-17T16:41:52.626579Z [15.340768657] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"launchApp"} Service security groups don't allow method call.
2020-05-17T16:41:52.626622Z [15.340808153] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"launchApp"} Service security groups don't allow method call.
2020-05-17T16:41:52.626646Z [15.340832108] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"launchApp"} Service security groups don't allow method call.
2020-05-17T16:41:52.626669Z [15.340881442] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"listRunningApps"} Service security groups don't allow method call.
2020-05-17T16:41:52.626726Z [15.340911733] user.warning LunaWebAppManager [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"(null)","CATEGORY":"/","METHOD":"registerForAppEvents"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>