### PR TITLE
QML container: fix QML imports

### DIFF
--- a/src/qml/ApplicationContainer.qml
+++ b/src/qml/ApplicationContainer.qml
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-import QtQuick 2.6
+import QtQuick 2.12
+import QtQuick.Window 2.12
 import QtWebEngine 1.4
 import QtWebChannel 1.0
 import Qt.labs.settings 1.0

--- a/src/qml/InAppBrowser.qml
+++ b/src/qml/InAppBrowser.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-import QtQuick 2.0
+import QtQuick 2.12
 import LuneOS.Components 1.0
 import LunaNext.Common 0.1
 


### PR DESCRIPTION
 - missing QtQuick.Window import
 - bump QtQuick to 5.12

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>