### PR TITLE
ApplicationContainer.qml: Fix implictly defined functions for Connect…

### DIFF
--- a/src/qml/ApplicationContainer.qml
+++ b/src/qml/ApplicationContainer.qml
@@ -113,8 +113,12 @@ Flickable {
 
             Connections {
                 target: Qt.inputMethod
-                onVisibleChanged: webView._updateWebViewSize();
-                onKeyboardRectangleChanged: webView._updateWebViewSize();
+                function onVisibleChanged () {
+                    webView._updateWebViewSize();
+                }
+                function onKeyboardRectangleChanged () {
+                    webView._updateWebViewSize();
+                }
             }
 
 
@@ -122,7 +126,11 @@ Flickable {
             focus: true
             Connections {
                 target: webAppWindow
-                onFocusChanged: if(!webAppWindow.focus) webView.focus = false;
+                function onFocusChanged() { 
+                    if(!webAppWindow.focus) {
+                        webView.focus = false;
+                    }
+                }
             }
 
             backgroundColor: (webAppWindow.windowType === "dashboard" || webAppWindow.windowType === "popupalert") ? "transparent": "white"
@@ -196,12 +204,12 @@ Flickable {
             Connections {
                 target: webAppWindow
 
-                onJavaScriptExecNeeded: {
+                function onJavaScriptExecNeeded(script) {
                     // beware: async call
                     webView.runJavaScript(script);
                 }
 
-                onExtensionWantsToBeAdded: {
+                function onExtensionWantsToBeAdded(name, object) {
                     console.warn("registering " + name + "to WebChannel: " + object);
                     webViewChannel.registerObject(name, object);
                 }


### PR DESCRIPTION
…ions

Solves:

Jun 08 16:47:00 qemux86-64 LunaWebAppManager[731]: WARNING: 16:47:00.872: qrc:/qml/ApplicationContainer.qml:196:13: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
Jun 08 16:47:00 qemux86-64 LunaWebAppManager[731]: WARNING: 16:47:00.872: qrc:/qml/ApplicationContainer.qml:123:13: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
Jun 08 16:47:00 qemux86-64 LunaWebAppManager[731]: WARNING: 16:47:00.872: qrc:/qml/ApplicationContainer.qml:114:13: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>