### PR TITLE
org.webosports.webappmanager.perm.json: Fix permissions for qtpositio…

### DIFF
--- a/files/sysbus/org.webosports.webappmanager.perm.json
+++ b/files/sysbus/org.webosports.webappmanager.perm.json
@@ -25,5 +25,8 @@
         "signals.all",
         "signals.register",
         "system"
+    ],
+    "qtpositioning_LunaWebAppMgr": [
+        "services"
     ]
 }


### PR DESCRIPTION
…ning

Seems the previous commit was somehow faulty and was not including the required fix (probably dropped it instead of squashing it), this will fix it:

Jun 23 15:03:43 qemux86-64 location-service[453]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"qtpositioning_LunaWebAppMgr","CATEGORY":"/","METHOD":"startTracking"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>